### PR TITLE
GraphQL rules in 0x23 - V18 were only added in 4.0

### DIFF
--- a/4.0/en/0x23-V18-API.md
+++ b/4.0/en/0x23-V18-API.md
@@ -22,9 +22,9 @@ Previous requirements in this standard apply to APIs as well (access control, se
 | **18.7** | Verify that REST services explicitly check the incoming Content-Type to be the expected one, such as application/xml or application/JSON. |  | ✓ | ✓ | 3.0 |
 | **18.8** | Verify that the message payload is signed to ensure reliable transport between client and service, using JSON Web Signing or WS-Security for SOAP requests. |  | ✓ | ✓ | 3.0.1 |
 | **18.9** | Verify API URLs do not expose sensitive information, such as the API key, session tokens etc. |  | ✓ | ✓ | 4.0 |
-| **18.10** | Verify that authorization decisions are made at both the URI and resource level, not just at the resource level. |  | ✓ | ✓ | 3.0 |
-| **18.11** | If GraphQL is used, to prevent DoS as a result of expensive, nested queries, query whitelisting or a combination of depth limiting and amount limiting should be used. For more advanced scenarios, query cost analysis should be used. |  | ✓ | ✓ | 3.0 |
-| **18.12** | If GraphQL is used, authorization logic should be implemented at the business logic layer instead of the GraphQL layer. |  | ✓ | ✓ | 3.0 |
+| **18.10** | Verify that authorization decisions are made at both the URI and resource level, not just at the resource level. |  | ✓ | ✓ | 4.0 |
+| **18.11** | If GraphQL is used, to prevent DoS as a result of expensive, nested queries, query whitelisting or a combination of depth limiting and amount limiting should be used. For more advanced scenarios, query cost analysis should be used. |  | ✓ | ✓ | 4.0 |
+| **18.12** | If GraphQL is used, authorization logic should be implemented at the business logic layer instead of the GraphQL layer. |  | ✓ | ✓ | 4.0 |
 | **18.13** | If no access control is present, verify that the REST service isn't susceptible to excessive calls, which could lead to increased overhead or CPU/bandwidth bills. A potential solution could be API keys, or implementing anti-automation techniques such as rate limiting, or quotas. |  | ✓ | ✓ | 4.0 |
 | **18.14** | Verify that requests containing unexpected or missing content types are rejected with appropriate headers (HTTP response status 406 Unacceptable or 415 Unsupported Media Type). |  | ✓ | ✓ | 4.0 |
 


### PR DESCRIPTION
The rules about GraphQL  (18.11, 18.12) and the one about authorization decisions on URI and resource level (18.10) were only added in the recent 4.0 draft. Neither rule is part of the published 3.0.1 PDF